### PR TITLE
Install tools using go install instead of go get.

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -87,7 +87,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
     set noshellslash
   endif
 
-  let l:get_base_cmd = ['go', 'get', '-v']
+  let l:get_base_cmd = ['go', 'install', '-v']
 
   " Filter packages from arguments (if any).
   let l:packages = {}


### PR DESCRIPTION
As part of recent deprecation of `go get` as a method to install packages in go v1.17+ this commit will add the change made for the original [vim-go](https://github.com/fatih/vim-go) plugin. [Here](https://github.com/fatih/vim-go/issues/3316) is the issue raised for the original release.