### PR TITLE
Fix neovim error with noshellslash

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -91,7 +91,9 @@ endfunction
 function! go#util#Shelljoin(arglist, ...) abort
   try
     let ssl_save = &shellslash
-    set noshellslash
+    if has("win32")
+      set noshellslash
+    endif
     if a:0
       return join(map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')'), ' ')
     endif


### PR DESCRIPTION
Neovim disallows `set noshellslash` outside of win32 and most `set noshellslash` lines in vim-gofmt are already wrapped with a `if has("win32")`.

Vim-Go had a similar problem (https://github.com/fatih/vim-go/issues/3690) and also fixed it by wrapping in `if has("win32")`: with https://github.com/fatih/vim-go/issues/3690.